### PR TITLE
Modify: 検索アルゴリズムを改良

### DIFF
--- a/src/components/Search/algorithm/monkukuiDistance.js
+++ b/src/components/Search/algorithm/monkukuiDistance.js
@@ -30,8 +30,6 @@ function tokenize(str) {
   .flat();
 }
 
-
-
 export default function monkukuiDistance( s, t ) {
   
   let u = tokenize(s);
@@ -41,7 +39,12 @@ export default function monkukuiDistance( s, t ) {
   let ret = 0;
   for (let i = 0; i < u.length; i++) {
     for (let j = 0; j < v.length; j++) {
-      if (u[i] == v[j]) ret++;
+      // if (u[i] == v[j]) ret++;
+      if (Math.min(u[i].length, v[j].length) <= 2) {
+        if (u[i] === v[j]) ret++;
+      } else {
+        if (levenshteinDistance(u[i], v[j]) <= 2) ret++;
+      }
     }
   }
 


### PR DESCRIPTION
### やったこと
- 文字列長が 2 以下のときは，完全一致しか認めない
- それ以外の時は，編集距離を計算して，2 以下なら hit と判定
### 結果
- 「合同企業説明会」で「合同説明会」が hit
- 「マイナ」で「マイナビ」が hit
- 「a」とかでは何もヒットしない（一番最初の検索アルゴリズムでは，これが hit してしまっていた）
<img width="735" alt="スクリーンショット 2020-03-28 1 30 54" src="https://user-images.githubusercontent.com/47474057/77778435-5282dc80-7094-11ea-8fe2-f6c14a55739d.png">
<img width="1112" alt="スクリーンショット 2020-03-28 1 31 38" src="https://user-images.githubusercontent.com/47474057/77778439-53b40980-7094-11ea-8d78-bf2909fda922.png">

